### PR TITLE
Allow YOLO models in same directory

### DIFF
--- a/impact/subpack_nodes.py
+++ b/impact/subpack_nodes.py
@@ -24,6 +24,8 @@ class UltralyticsDetectorProvider:
 
     def doit(self, model_name):
         model_path = folder_paths.get_full_path("ultralytics", model_name)
+        if model_path is None and (model_name.startswith("bbox/") or model_name.startswith("segm/")):    # Allow segm/bbox models to be located in the same folder for shared model storage with other UIs
+            model_path = folder_paths.get_full_path("ultralytics", model_name[5:])
         model = subcore.load_yolo(model_path)
 
         if model_name.startswith("bbox"):


### PR DESCRIPTION
### Problem
The YOLO models must currently be split into the segm/ and bbox/ folders which does not allow to share the models with other nodes/UIs which use a unified folder

### Solution
In case the initial path lookup using the bbox/ or segm/ folder fails/has no results it will instead check the parent folder and try to load it from there, making it possible to put files directly in the "ultralytics" folder instead of "ultralytics_segm" and "ultralytics_bbox"

### Caveats
The UI will show every model twice using the bbox/ and segm/ prefix. I see no way to fix this without fundamental changes to the whole model-loading part. This also means that whoever puts the files in a shared folder must also be aware what is a segmentation model and what is a detection/box model an wire it accordingly.