### PR TITLE
Add the `dill` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib
 ultralytics==8.3.40
 numpy==1.26.4
 opencv-python-headless
+dill


### PR DESCRIPTION
This subpack depends on the `dill` library, but this isn't listed in the `requirements.txt`.